### PR TITLE
updated the default ossBucketKey

### DIFF
--- a/server/forge.js
+++ b/server/forge.js
@@ -42,7 +42,7 @@ router.get('/forge/oauth/token', function (req, res) {
   })
 });
 
-var ossBucketKey = process.env.FORGE_BUCKET || 'navigationsample3d2d';
+var ossBucketKey = process.env.FORGE_BUCKET || 'someveryuniquename2d3d';//'navigationsample3d2d';
 
 router.get('/forge/models', function (req, res) {
   var t = new token();


### PR DESCRIPTION
Some users reports problems in using this sample, and it turns out that the 'navigationsample3d2d' string used as default ossBucketKey is the cause. The ossBucketKey  has to be unique, but apparently the 'navigationsample3d2d' one already exist for all users?

I think another approach is to change the README file and direct users to set the FORGE_BUCKET env variable, but it might create confusions.
For more info see the following complaint: http://stackoverflow.com/questions/40594207/loading-a-model-into-the-2d-3d-viewer-autodesk-forge/40598873#40598873
